### PR TITLE
fix charge unit scaler for ibm catalog scraper

### DIFF
--- a/src/scrapers/ibmCatalog.ts
+++ b/src/scrapers/ibmCatalog.ts
@@ -262,7 +262,7 @@ function getPrices(
         prices.push({
           priceHash: `${chargeUnitName}-${chargeUnitQty}-${country}-${currency}-${quantityTier}-${partNumber}`,
           purchaseOption: String(chargeUnitQty),
-          USD: String(price),
+          USD: String(price / parseInt(chargeUnitQty ?? "1", 10)),
           startUsageAmount: prevCost?.quantity_tier
             ? String(prevCost?.quantity_tier)
             : '0',


### PR DESCRIPTION
The VPN Gateway for VPC resource has a 100 charge unit quantity scaler.