### PR TITLE
fix logger library and callback functions with error

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,6 @@
   ],
   "dependencies": {
     "@apollo/server": "^4.11.0",
-    "@console/console-platform-log4js-utils": "^4.1.0",
     "@graphql-tools/schema": "^9.0.12",
     "@graphql-tools/utils": "^9.1.3",
     "@ibm-cloud/platform-services": "^0.47.0",

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,6 +1,5 @@
 import dotenv from 'dotenv';
-import * as loggerUtils from '@console/console-platform-log4js-utils';
-import NodeCache from 'node-cache';
+import * as log4js from 'log4js';import NodeCache from 'node-cache';
 import { Pool, PoolConfig } from 'pg';
 import tmp from 'tmp';
 import fs from 'fs';
@@ -132,7 +131,7 @@ function generateGcpKeyFile(): string {
   return tmpFile.name;
 }
 
-const logger = loggerUtils.getLogger('cloud-pricing-api');
+const logger = log4js.getLogger('cloud-pricing-api');
 
 const cache = new NodeCache();
 

--- a/src/scrapers/awsBulk.ts
+++ b/src/scrapers/awsBulk.ts
@@ -138,9 +138,9 @@ async function downloadService(offer: Offer, prefix?: string) {
         `data/${prefix}-${offer.offerCode}-${region.regionCode}.json`
       );
       resp.data.pipe(writer);
-      await new Promise((resolve) => {
-        writer.on('finish', resolve);
-      });
+        await new Promise<void>((resolve) => {
+  writer.on('finish', () => resolve());
+});
     }
   } else {
     config.logger.info(`Downloading ${offer.currentVersionUrl}`);
@@ -153,8 +153,8 @@ async function downloadService(offer: Offer, prefix?: string) {
       `data/${prefix}-${offer.offerCode}.json`
     );
     resp.data.pipe(writer);
-    await new Promise((resolve) => {
-      writer.on('finish', resolve);
+    await new Promise<void>((resolve) => {
+      writer.on('finish', () => resolve());
     });
   }
 }

--- a/src/scrapers/gcpCatalog.ts
+++ b/src/scrapers/gcpCatalog.ts
@@ -132,8 +132,8 @@ async function downloadService(service: ServiceJson): Promise<void> {
     filename = `data/${filename}.json`;
     const writer = fs.createWriteStream(filename);
     resp.data.pipe(writer);
-    await new Promise((resolve) => {
-      writer.on('finish', resolve);
+    await new Promise<void>((resolve) => {
+      writer.on('finish', () => resolve());
     });
 
     const body = fs.readFileSync(filename);


### PR DESCRIPTION
Issue 1:
NPM Dependency is not existing anymore and throwing issue when setting up the docker-compose:
"@console/console-platform-log4js-utils"

Actions done:
Replace "@console/console-platform-log4js-utils" logging with same 'log4js' features.

Issue 2:
Callback functions missing in AWS and GCP were throwing error.

Actions done:
Added callback function and type.