### PR TITLE
Show most recent version tag when starting the server

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -136,17 +136,6 @@ const logger = loggerUtils.getLogger('cloud-pricing-api');
 
 const cache = new NodeCache();
 
-// Represents the most recent version tag in the dataops/cloud-pricing-api repo
-// Reference: https://github.ibm.com/dataops/cloud-pricing-api/tags
-let tag_version
-
-if (process.env.IMAGE_VERSION) {
-  let index = process.env.IMAGE_VERSION.indexOf(":")
-  index !== -1 ? tag_version = process.env.IMAGE_VERSION.substring(index+1) : tag_version = process.env.IMAGE_VERSION
-} else {
-  tag_version = "local"
-}
-
 const config = {
   logger,
   pg,
@@ -172,7 +161,7 @@ const config = {
   ibmCloudApiKey: process.env.IBM_CLOUD_API_KEY,
   region: process.env.CLOUD_REGION || 'local',
   hostname: process.env.HOSTNAME || 'local',
-  version: tag_version
+  version: process.env.IMAGE_VERSION?.split(":")[1] || 'local' 
 };
 
 export default config;

--- a/src/server.ts
+++ b/src/server.ts
@@ -4,6 +4,6 @@ import config from './config';
 createApp().then((app) => {
   app.listen(config.port, () => {
     config.logger.info(`🚀  Server ready at http://0.0.0.0:${config.port}/`);
-    config.logger.info(`Most recent version tag: ${config.version}`)
+    config.logger.info(`Running version: ${config.version}`)
   });
 });


### PR DESCRIPTION
This commit adds a feature to show the most recent version tag when the server starts.

It takes the `IMAGE_VERSION` environment variable and splices it to take everything after the first ":".

Reference: https://github.ibm.com/dataops/cloud-pricing-api/tags

NOTE: the version tag on GitHub shows the package.json version with the tag version, whereas the version tag shown when the server starts is just the version tag.

E.g. 
GitHub: `0.3.10-20250617-141730-master-89`
Message shown when server starts: `20250617-141730-master-89`


## To test
- run: npm run build
- run: npm run start
- verify that the start message shows:  `Most recent version tag: <tag_version>`

<img width="847" alt="image" src="https://github.com/user-attachments/assets/51565d15-393b-4c48-8eb5-47d582336a7e" />
