### PR TITLE
Patch `minimatch` for CVE-2026-26996

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,6 @@
     "@graphql-tools/utils": "^9.1.3",
     "@ibm-cloud/platform-services": "^0.76.3",
     "@types/cors": "^2.8.17",
-    "@types/glob": "^8.1.0",
     "@types/jest": "^29.5.12",
     "@types/lodash": "^4.17.0",
     "@types/node": "^18.11.8",

--- a/package.json
+++ b/package.json
@@ -60,9 +60,9 @@
     "cpy-cli": "^5.0.0",
     "decimal.js": "^10.4.2",
     "dotenv": "^16.0.3",
-    "ejs": "^3.1.10",
+    "ejs": "^4.0.1",
     "express": "^4.21.2",
-    "glob": "^10.5.0",
+    "glob": "^11.1.0",
     "googleapis": "^144.0.0",
     "graphql": "^16.9.0",
     "graphql-tag": "^2.12.6",
@@ -80,7 +80,7 @@
     "yargs": "^17.6.2"
   },
   "overrides": {
-    "minimatch": "^5.1.7",
+    "minimatch": "^10.2.4",
     "brace-expansion": "^2.0.2"
   },
   "devDependencies": {


### PR DESCRIPTION
- Upversioned `glob` to `11.1.0` and `ejs` to `4.0.1`, which results in `minimatch` version `10.2.4`.
- Fixed TypeScript compilation errors by removing the incompatible `@types/glob@8.1.0` package. Version mismatch between `@types/glob@8.1.0` and `minimatch@10.2.4`. The old type definitions expected `IOptions` and `IMinimatch` interfaces that don't exist in minimatch v10.