### PR TITLE
fix: patch brace-expansion, body-parser, js-yaml, @babel/core and mingo vulnerabilities

### DIFF
--- a/package.json
+++ b/package.json
@@ -88,11 +88,13 @@
   },
   "overrides": {
     "minimatch": "^10.2.4",
-    "brace-expansion": "^2.0.2"
+    "brace-expansion": "^5.0.7",
+    "body-parser": "^1.20.6",
+    "js-yaml": "^4.3.0"
   },
   "devDependencies": {
-    "@babel/core": "^7.28.0",
-    "@babel/node": "7.28",
+    "@babel/core": "^8.0.1",
+    "@babel/node": "^8.0.1",
     "@eslint/js": "^9.17.0",
     "@types/express": "4.17.25",
     "@typescript-eslint/eslint-plugin": "^8.36.0",

--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     "graphql-upload": "^16.0.2",
     "lodash": "^4.17.23",
     "log4js": "^6.9.1",
-    "mingo": "^6.1.2",
+    "mingo": "^7.2.2",
     "node-cache": "^5.1.2",
     "pg": "^8.8.0",
     "pg-copy-streams": "^6.0.4",


### PR DESCRIPTION
Patches five security vulnerabilities in transitive and direct npm dependencies. All changes are confined to `package.json` and `package-lock.json` — no application source code was modified.

## Changes

- **`brace-expansion` override: `^2.0.2` → `^5.0.7`** — fixes CVE-2026-13149. The previous override was counterproductive: `minimatch@10.x` already requires `^5.0.5`, so the old override was actively downgrading it to a vulnerable 2.x version.
- **`body-parser` override: added `^1.20.6`** — fixes CVE-2026-12590. `express@4.x` pins `~1.20.5`; the override forces the patched patch release.
- **`js-yaml` override: added `^4.3.0`** — fixes GHSA-h67p-54hq-rp68 (DoS via merge key aliases). The installed version was `4.1.1`, within the vulnerable range `4.0.0–4.1.1`.
- **`@babel/core` + `@babel/node`: `7.x` → `^8.0.1`** — fixes GHSA-4x5r-pxfx-6jf8 (arbitrary file read via `sourceMappingURL`). Both are direct `devDependencies`; upgraded together since `@babel/node@8` requires `@babel/core@^8`.
- **`mingo`: `^6.1.2` → `^7.2.2`** — fixes CVE-2026-15698. Direct dependency; upgraded to the latest stable major release. The only usage (`mingo.find(...).all()`) is fully compatible with the v7 API — `find` and `Cursor.all()` are both present and unchanged in v7.

## Verification

- `npm audit` reports **0 vulnerabilities** after these changes
- `npm run build` (tsc) completes cleanly with no errors
- No application source code changes required (breaking changes in mingo v7 affect APIs not used in this codebase)

## Local Testing

```
-|---------|----------|---------|---------|-------------------
 | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s 
-|---------|----------|---------|---------|-------------------
 |       0 |        0 |       0 |       0 |                   
-|---------|----------|---------|---------|-------------------

=============================== Coverage summary ===============================
Statements   : Unknown% ( 0/0 )
Branches     : Unknown% ( 0/0 )
Functions    : Unknown% ( 0/0 )
Lines        : Unknown% ( 0/0 )
================================================================================
Test Suites: 3 passed, 3 total
Tests:       13 passed, 13 total
Snapshots:   0 total
Time:        21.41 s
Ran all test suites matching sanity*|daPrices.test.js.
```